### PR TITLE
Mint the v3 reCAPTCHA token on submit, not on page load

### DIFF
--- a/.ddev/config-craft4.yaml
+++ b/.ddev/config-craft4.yaml
@@ -1,0 +1,282 @@
+name: googlerecaptcha-craft4
+type: php
+docroot: ""
+php_version: "8.1"
+webserver_type: nginx-fpm
+xdebug_enabled: true
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "10.4"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+nodejs_version: "20"
+corepack_enable: false
+
+# Key features of DDEV's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+
+# type: <projecttype>  # backdrop, craftcms, django4, drupal, drupal6, drupal7, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress
+# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# information on the different project types
+# "drupal" covers recent Drupal 8+
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "8.2"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
+#   MySQL versions can be 5.5-8.0.
+#   PostgreSQL versions can be 9-17.
+
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
+
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
+
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
+
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
+
+# timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
+
+# nodejs_version: "20"
+# change from the default system Node.js version to any other version.
+# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
+
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, DDEV will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,83 +1,95 @@
-name: googlerecaptcha-craft4
+name: googlerecaptcha-craft5
 type: php
 docroot: ""
-php_version: "8.0"
+php_version: "8.2"
 webserver_type: nginx-fpm
-router_http_port: "80"
-router_https_port: "443"
 xdebug_enabled: true
 additional_hostnames: []
 additional_fqdns: []
 database:
-  type: mariadb
-  version: "10.4"
-nfs_mount_enabled: false
-mutagen_enabled: true
+    type: mariadb
+    version: "10.4"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-nodejs_version: "16"
+nodejs_version: "20"
+corepack_enable: false
 
-# Key features of ddev's config.yaml:
+# Key features of DDEV's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides
 #   http://projectname.ddev.site and https://projectname.ddev.site
 
-# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+# type: <projecttype>  # backdrop, craftcms, django4, drupal, drupal6, drupal7, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress
+# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# information on the different project types
+# "drupal" covers recent Drupal 8+
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.4"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"
+# php_version: "8.2"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"
 
 # You can explicitly specify the webimage but this
-# is not recommended, as the images are often closely tied to ddev's' behavior,
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>  # nginx/php docker image.
 
 # database:
-#   type: <dbtype> # mysql, mariadb
-#   version: <version> # database version, like "10.3" or "8.0"
-# Note that mariadb_version or mysql_version from v1.18 and earlier
-# will automatically be converted to this notation with just a "ddev config --auto"
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
+#   MySQL versions can be 5.5-8.0.
+#   PostgreSQL versions can be 9-17.
 
-# router_http_port: <port>  # Port to be used for http (defaults to port 80)
-# router_https_port: <port> # Port for https (defaults to 443)
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
 
-# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
-# as leaving xdebug enabled all the time is a big performance hit.
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
 
-# xhprof_enabled: false  # Set to true to enable xhprof and "ddev start" or "ddev restart"
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
-# as leaving xhprof enabled all the time is a big performance hit.
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm  # or apache-fpm
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
 
 # timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
 # This is the timezone used in the containers and by PHP;
 # it can be set to any valid timezone,
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # For example Europe/Dublin or MST7MDT
 
 # composer_root: <relative_path>
-# Relative path to the composer root directory from the project root. This is
+# Relative path to the Composer root directory from the project root. This is
 # the directory which contains the composer.json and where all Composer related
 # commands are executed.
 
 # composer_version: "2"
-# if composer_version:"2" it will use the most recent composer v2
-# It can also be set to "1", to get most recent composer v1
-# or "" for the default v2 created at release time.
-# It can be set to any existing specific composer version.
-# After first project 'ddev start' this will not be updated until it changes
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
 
-# nodejs_version: "16"
-# change from the default system Node.js version to another supported version, like 12, 14, 17.
-# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
-# Node.js version, including v6, etc.
+# nodejs_version: "20"
+# change from the default system Node.js version to any other version.
+# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
 
 # additional_hostnames:
 #  - somename
@@ -91,8 +103,26 @@ nodejs_version: "16"
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
 
-# upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
 
 # working_dir:
 #   web: /var/www/html
@@ -101,20 +131,25 @@ nodejs_version: "16"
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: [db, dba, ddev-ssh-agent]
+# omit_containers: [db, ddev-ssh-agent]
 # Currently only these containers are supported. Some containers can also be
 # omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
-# the "db" container, several standard features of ddev that access the
+# the "db" container, several standard features of DDEV that access the
 # database container will be unusable. In the global configuration it is also
 # possible to omit ddev-router, but not here.
 
-# nfs_mount_enabled: false
-# Great performance improvement but requires host configuration first.
-# See https://ddev.readthedocs.io/en/stable/users/performance/#using-nfs-to-mount-the-project-into-the-container
-
-# mutagen_enabled: false
-# Experimental performance improvement using mutagen asynchronous updates.
-# See https://ddev.readthedocs.io/en/latest/users/performance/#using-mutagen
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -135,20 +170,12 @@ nodejs_version: "16"
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
-# phpmyadmin_port: "8036"
-# phpmyadmin_https_port: "8037"
-# The PHPMyAdmin ports can be changed from the default 8036 and 8037
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
 
-# host_phpmyadmin_port: "8036"
-# The phpmyadmin (dba) port is not normally bound on the host at all, instead being routed
-# through ddev-router, but it can be specified and bound.
-
-# mailhog_port: "8025"
-# mailhog_https_port: "8026"
-# The MailHog ports can be changed from the default 8025 and 8026
-
-# host_mailhog_port: "8025"
-# The mailhog port is not normally bound on the host at all, instead being routed
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
 # through ddev-router, but it can be bound directly to localhost if specified here.
 
 # webimage_extra_packages: [php7.4-tidy, php-bcmath]
@@ -169,36 +196,87 @@ nodejs_version: "16"
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --subdomain mysite --auth username:pass
+# ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
 
 # disable_settings_management: false
-# If true, ddev will not create CMS-specific settings files like
-# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
 # In this case the user must provide all such settings.
 
 # You can inject environment variables into the web container with:
 # web_environment:
-# - SOMEENV=somevalue
-# - SOMEOTHERENV=someothervalue
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
 
 # no_project_mount: false
-# (Experimental) If true, ddev will not mount the project into the web container;
+# (Experimental) If true, DDEV will not mount the project into the web container;
 # the user is responsible for mounting it manually or via a script.
 # This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
 # bind_all_interfaces: false
 # If true, host ports will be bound on all network interfaces,
-# not just the localhost interface. This means that ports
+# not the localhost interface only. This means that ports
 # will be available on the local network if the host firewall
 # allows it.
 
-# Many ddev commands can be extended to run tasks before or after the
-# ddev command is executed, for example "post-start", "post-import-db",
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
     name: ECS
     uses: juban/.github/.github/workflows/ecs.yml@main
     with:
-      php_version: '8.0'
+      php_version: '8.1'
   phpstan:
     name: PHPStan
     uses: juban/.github/.github/workflows/phpstan.yml@main
     with:
-      php_version: '8.0'
+      php_version: '8.1'
   codecept:
     name: Codeception
     needs: [ ecs, phpstan ]
     uses: juban/.github/.github/workflows/codecept.yml@main
     with:
-      php_version: '8.0'
+      php_version: '8.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,87 @@
 # Google Recaptcha Changelog
 
-## 3.0.0 - 2024-11-05
+## 3.0.0 - 2024-11-06
 
 ### Added
+
 - Craft 5 support
-- v3 `formId` option in order to prevent `timeout-or-duplicate` errors if the form takes more than 2 minutes to be submited (#8)
+- v3 `formId` option in order to prevent `timeout-or-duplicate` errors if the form takes more than 2 minutes to be
+  submitted (#8)
+- New `getVersion` and `getSiteKey` Twig variables
 
 ## 2.3.0 - 2023-01-22
 
 ### Added
+
 - `BeforeRecaptchaVerifyEvent` event to bypass or cancel the reCAPTCHA verification (original request by @creode-dev)
 
 ## 2.2.0 - 2022-08-15
 
 ### Added
+
 - Ability to set script tags extra attributes (original request by @jcdarwin for CSP compliance)
 
 ## 2.1.0 - 2022-07-23
 
-> {note} The plugin’s package name has changed to `jub/craft-google-recaptcha`. You can update the plugin by running `composer require jub/craft-google-recaptcha && composer remove simplonprod/craft-google-recaptcha`.
+> {note} The plugin’s package name has changed to `jub/craft-google-recaptcha`. You can update the plugin by running
+`composer require jub/craft-google-recaptcha && composer remove simplonprod/craft-google-recaptcha`.
 
 ### Changed
+
 - Migrate plugin to `jub/craft-google-recaptcha`
 - Updated plugin logo
 
-
 ## 2.0.2 - 2022-05-13
+
 ### Fixed
+
 - Fix an exception that could occur in verify method if no actions parameters were saved (merged from 1.1.1)
 
 ## 2.0.1 - 2022-05-09
 
 ### Fixed
+
 - reCAPTCHA v3 actions parameters were missing from the control panel
 
 ## 2.0.0 - 2022-05-08
 
 ### Added
+
 - Added Craft 4 compatibility.
 
 ## 1.1.1 - 2022-05-13
+
 ### Fixed
+
 - Fix an exception that could occur in verify method if no actions parameters were saved.
 
 ## 1.1.0 - 2022-03-07
+
 ### Added
+
 - (v3 API) Default action name and score threshold can be configured
 - (v3 API) Score threshold can be defined per action
 - (v3 API) Ability to specify the action name in the twig `craft.googleRecaptcha.render()` function first parameter.
 
 ### Changed
+
 - Google reCAPTCHA plugin options can now be set using environment variables
 - Bump minimum required Craft version to 3.7.29
 
 ## 1.0.4 - 2021-05-03
+
 ### Added
+
 - Contact form instructions in README
 
 ### Changed
+
 - Updated plugin icon
 
 ## 1.0.3 - 2021-05-01
+
 ### Changed
+
 - Update docs, issues and changelog links in composer.json
 - Upgrade codeception to v4
 - Fix composer dependencies
@@ -69,17 +89,24 @@
 - Various small refactoring
 
 ## 1.0.2 - 2021-04-20
+
 ### Added
+
 - Full unit and functional tests coverage
 
 ### Changed
+
 - Templates to render v2 and v3 tags
 - More robust settings validation rules
 
 ## 1.0.1 - 2021-04-07
+
 ### Added
+
 - instantRender parameter to twig render method (for v2 ajax calls context)
 
 ## 1.0.0 - 2021-04-01
+
 ### Added
+
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Google Recaptcha Changelog
 
+## 3.0.0 - 2024-11-05
+
+### Added
+- Craft 5 support
+- v3 `formId` option in order to prevent `timeout-or-duplicate` errors if the form takes more than 2 minutes to be submited (#8)
+
 ## 2.3.0 - 2023-01-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google reCAPTCHA plugin for Craft CMS 4
+# Google reCAPTCHA plugin for Craft CMS
 
 [![Stable Version](https://img.shields.io/packagist/v/jub/craft-google-recaptcha?label=stable)]((https://packagist.org/packages/jub/craft-google-recaptcha))
 [![Total Downloads](https://img.shields.io/packagist/dt/jub/craft-google-recaptcha)](https://packagist.org/packages/jub/craft-google-recaptcha)

--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@
 
 ![](logo.png)
 
-
-
-Google reCAPTCHA for Craft CMS enables to render and validate the reCAPTCHA widget. It is compatible with both API v2 and v3, including checkbox badge and invisible flavors.
+Google reCAPTCHA for Craft CMS enables to render and validate the reCAPTCHA widget. It is compatible with both API v2
+and v3, including checkbox badge and invisible flavors.
 
 ## Requirements
 
 This plugin requires Craft CMS 4.0.0 or later and PHP 8.0.2 or later.
 
-To use the plugin, you will need to get an API site key and secret key which you can configure [here](https://www.google.com/recaptcha/admin).
+To use the plugin, you will need to get an API site key and secret key which you can
+configure [here](https://www.google.com/recaptcha/admin).
 
 ## Installation
 
-1. Install with composer via `composer require jub/craft-google-recaptcha` from your project directory or from the Plugin Store section of the Control Panel.
-2. Install the plugin in the Craft Control Panel under Settings → Plugins, or from the command line via `./craft plugin/install google-recaptcha`.
-
+1. Install with composer via `composer require jub/craft-google-recaptcha` from your project directory or from the
+   Plugin Store section of the Control Panel.
+2. Install the plugin in the Craft Control Panel under Settings → Plugins, or from the command line via
+   `./craft plugin/install google-recaptcha`.
 
 ## Configuration
 
@@ -28,17 +29,20 @@ To use the plugin, you will need to get an API site key and secret key which you
 
 You can manage configuration setting through the Control Panel by going to Settings → Google reCAPTCHA
 
-* Provide the Site Key and the Secret Key obtained from [your reCAPTCHA account](https://www.google.com/recaptcha/admin).
+* Provide the Site Key and the Secret Key obtained
+  from [your reCAPTCHA account](https://www.google.com/recaptcha/admin).
 * Select the API version accordingly to the reCAPTCHA type you created the keys upon.
-* For v2 API, select the following parameters: 
-	* Size: Select the size of the reCAPTCHA widget. 
-	* Theme: Select the color theme of the reCAPTCHA widget.
-	* Badge: Select the position of the reCAPTCHA badge.
-* For v3 API: 
-	* Default Action: the default action name to be used during reCAPTCHA verification. Defaults to `homepage` if blank.
-	* Default Score Threshold : Minimum score between 0 and 1 to obtain in order for the end user to validate the reCAPTHCHA challenge (see [here](https://developers.google.com/recaptcha/docs/v3#interpreting_the_score) for help on interpreting the score)
-. Leave blank for no score checking. 	
-	* Actions: A score threshold can be defined per action here.
+* For v2 API, select the following parameters:
+    * Size: Select the size of the reCAPTCHA widget.
+    * Theme: Select the color theme of the reCAPTCHA widget.
+    * Badge: Select the position of the reCAPTCHA badge.
+* For v3 API:
+    * Default Action: the default action name to be used during reCAPTCHA verification. Defaults to `homepage` if blank.
+    * Default Score Threshold : Minimum score between 0 and 1 to obtain in order for the end user to validate the
+      reCAPTHCHA challenge (see [here](https://developers.google.com/recaptcha/docs/v3#interpreting_the_score) for help
+      on interpreting the score)
+      . Leave blank for no score checking.
+    * Actions: A score threshold can be defined per action here.
 
 ### Configuration file
 
@@ -76,36 +80,54 @@ You can integrate the Google reCAPTCHA widget in your Twig templates as follow:
 {{ craft.googleRecaptcha.render() }}
 ```
 
-The `render` method accept an optional parameter in which you can provide any HTML attributes to apply to the widget container (div for v2, hidden input for v3).  
+The `render` method accept an optional parameter in which you can provide any HTML attributes to apply to the widget
+container (div for v2, hidden input for v3).  
 For example, to provide a container id, you can do:
-
 
 ```twig
 {{ craft.googleRecaptcha.render({id: 'recaptcha-widget'}) }}
 ```
 
-For v3 API, an action property can also be provided as follow:
+> 💡 For v2 API, you can provide a second boolean argument to the render method to trigger the instant rendering of the
+> widget (ie. `{{ craft.googleRecaptcha.render({ id: 'recaptcha-widget' }, true) }}`).
+> This is useful if you are working with views loaded through Ajax or [Sprig](https://plugins.craftcms.com/sprig) calls
+> and you need to refresh the widget.
+
+#### v3 special options
+
+##### Action
+
+An `[action](https://developers.google.com/recaptcha/docs/v3?hl=fr#actions)` property can be provided as follow:
 
 ```twig
 {{ craft.googleRecaptcha.render({id: 'recaptcha-widget', action: 'some_action_name'}) }}
 ```
 
-In that case, the score threshold to be used for that action can be defined in the "Actions Settings" part of the plugin control panel.
+In that case, the score threshold to be used for that action can be defined in the "Actions Settings" part of the plugin
+control panel.
 
-> 💡 For v2 API, you can provide a second boolean argument to the render method to trigger the instant rendering of the widget (ie. `{{ craft.googleRecaptcha.render({ id: 'recaptcha-widget' }, true) }}`). 
-> This is useful if you are working with views loaded through Ajax or [Sprig](https://plugins.craftcms.com/sprig) calls and you need to refresh the widget.
+##### Form ID
+
+To prevent v3 reCAPTCHA 2 minutes timeout, you can provide à `formId` option to specify the protected form id:
+
+```twig
+{{ craft.googleRecaptcha.render({id: 'recaptcha-widget', formId: 'some-form-id'}) }}
+```
+
+In that case, reCAPTCHA will be executed upon submit event of the form.
 
 #### Setting scripts extra attributes
 
-In the first render parameter, `scriptOptions` special property can be used to add extra attributes to the generated scripts tags.
+In the first render parameter, `scriptOptions` special property can be used to add extra attributes to the generated
+scripts tags.
 
-For example, to support Content Security Policy (CSP), assuming you are using the [Sherlock](https://plugins.craftcms.com/sherlock) security plugin, you could do the following:
+For example, to support Content Security Policy (CSP), assuming you are using
+the [Sherlock](https://plugins.craftcms.com/sherlock) security plugin, you could do the following:
 
 ```twig
 {% set nonce = craft.sherlock.getNonce() %}
 {{ craft.googleRecaptcha.render({scriptOptions: {'nonce': nonce}}) }}
 ```
-
 
 ### Verify users submissions
 
@@ -115,7 +137,7 @@ To validate a user submission on server side, you can use the built-in method:
 GoogleRecaptcha::$plugin->recaptcha->verify();
 ```
 
-For example, in a module controller, you could do something like this:
+For example, in a [module](https://craftcms.com/docs/5.x/extend/module-guide.html) controller, you could do something like this:
 
 ```php
 public function actionSubmitForm() {
@@ -131,7 +153,9 @@ public function actionSubmitForm() {
 
 ### Verify Guest Entries submissions
 
-In order to add a reCAPTCHA verification when working with [Craft Guest Entries plugin](https://plugins.craftcms.com/guest-entries), you can do something like the following in a project module:
+In order to add a reCAPTCHA verification when working
+with [Craft Guest Entries plugin](https://plugins.craftcms.com/guest-entries), you can do something like the following
+in a project module:
 
 ```php
 Event::on(SaveController::class, SaveController::EVENT_BEFORE_SAVE_ENTRY, function (SaveEvent $e) {
@@ -150,7 +174,8 @@ Event::on(SaveController::class, SaveController::EVENT_BEFORE_SAVE_ENTRY, functi
 
 ### Verify Contact Form submissions
 
-In order to add a reCAPTCHA verification when working with [Contact Form](https://plugins.craftcms.com/contact-form), you can do something like the following in a project module:
+In order to add a reCAPTCHA verification when working with [Contact Form](https://plugins.craftcms.com/contact-form),
+you can do something like the following in a project module:
 
 ```php
 Event::on(Submission::class, Submission::EVENT_AFTER_VALIDATE, function(Event $e) {
@@ -167,8 +192,11 @@ Event::on(Submission::class, Submission::EVENT_AFTER_VALIDATE, function(Event $e
 
 ### Available events
 
-* The `\juban\googlerecaptcha\events\BeforeRecaptchaVerifyEvent` event is triggered just before a reCAPTCHA verification is performed. You can use that event to:
-	* **Bypass the verification** by setting the `skipVerification` event property to `true`. In that case, verification will be considered as successful.
-	* **Cancel the verification** by setting the `isValid` event property to `false`. In that case, verification will be considered as failed.
+* The `\juban\googlerecaptcha\events\BeforeRecaptchaVerifyEvent` event is triggered just before a reCAPTCHA verification
+  is performed. You can use that event to:
+    * **Bypass the verification** by setting the `skipVerification` event property to `true`. In that case, verification
+      will be considered as successful.
+    * **Cancel the verification** by setting the `isValid` event property to `false`. In that case, verification will be
+      considered as failed.
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and v3, including checkbox badge and invisible flavors.
 
 ## Requirements
 
-This plugin requires Craft CMS 4.0.0 or later and PHP 8.0.2 or later.
+This plugin requires Craft CMS 4 or 5 and PHP 8.0.2 or later.
 
 To use the plugin, you will need to get an API site key and secret key which you can
 configure [here](https://www.google.com/recaptcha/admin).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ the [Sherlock](https://plugins.craftcms.com/sherlock) security plugin, you could
 {{ craft.googleRecaptcha.render({scriptOptions: {'nonce': nonce}}) }}
 ```
 
+#### Custom reCAPTCHA Widget
+
+If the default widget generation using the Twig command `craft.googleRecaptcha.render` does not meet your needs, you
+can generate your own using the plugin settings:
+
+* Get the API Version (ie `2` or `3`): `{{ craft.googleRecaptcha.version }}`
+* Get the Site Key (parsed value): `{{ craft.googleRecaptcha.siteKey }}`
+
+> 💡 If you need even more detailed configuration, you can still access every plugin settings by using
+`{{ craft.app.plugins.plugin('google-recaptcha').settings }}`
+
 ### Verify users submissions
 
 To validate a user submission on server side, you can use the built-in method:
@@ -137,7 +148,8 @@ To validate a user submission on server side, you can use the built-in method:
 GoogleRecaptcha::$plugin->recaptcha->verify();
 ```
 
-For example, in a [module](https://craftcms.com/docs/5.x/extend/module-guide.html) controller, you could do something like this:
+For example, in a [module](https://craftcms.com/docs/5.x/extend/module-guide.html) controller, you could do something
+like this:
 
 ```php
 public function actionSubmitForm() {

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ control panel.
 
 ##### Form ID
 
-To prevent v3 reCAPTCHA 2 minutes timeout, you can provide à `formId` option to specify the protected form id:
+To prevent the widget from expiring after 2 minutes, you should provide a `formId` option to specify the ID of the
+protected form:
 
 ```twig
 {{ craft.googleRecaptcha.render({id: 'recaptcha-widget', formId: 'some-form-id'}) }}

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For example, to provide a container id, you can do:
 
 ##### Action
 
-An `[action](https://developers.google.com/recaptcha/docs/v3?hl=fr#actions)` property can be provided as follow:
+An [`action`](https://developers.google.com/recaptcha/docs/v3?hl=fr#actions) property can be provided as follow:
 
 ```twig
 {{ craft.googleRecaptcha.render({id: 'recaptcha-widget', action: 'some_action_name'}) }}

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,7 +1,7 @@
 actor: Tester
 paths:
   tests: tests
-  log: tests/_output
+  output: tests/_output
   data: tests/_data
   support: tests/_support
   envs: tests/_envs
@@ -34,7 +34,7 @@ modules:
         google-recaptcha:
           class: '\juban\googlerecaptcha\GoogleRecaptcha'
           handle: google-recaptcha
-      cleanup: false
+      cleanup: true
       transaction: true
       dbSetup: {clean: true, setupCraft: true}
       fullMock: false

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jub/craft-google-recaptcha",
   "description": "Google reCAPTCHA for Craft CMS",
   "type": "craft-plugin",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "keywords": [
     "craft",
     "cms",
@@ -22,17 +22,18 @@
     }
   ],
   "require": {
-    "php": "^8.0.2",
-    "craftcms/cms": "^4.0"
+    "php": "^8.2",
+    "craftcms/cms": "^4.0|^5.0"
   },
   "require-dev": {
-    "codeception/codeception": "^4.0.0",
-    "vlucas/phpdotenv": "^3.0",
-    "codeception/module-yii2": "^1.0.0",
-    "codeception/module-asserts": "^1.0.0",
-    "codeception/module-db": "^1.1",
+    "codeception/codeception": "^5.0.11",
+    "codeception/module-asserts": "^3.0.0",
+    "codeception/module-yii2": "^1.1.9",
+    "codeception/lib-innerbrowser": "4.0.1",
+    "vlucas/phpdotenv": "^5.4.0",
     "craftcms/ecs": "dev-main",
-    "craftcms/phpstan": "dev-main"
+    "craftcms/phpstan": "dev-main",
+    "craftcms/rector": "dev-main"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": "^8.2",
+    "php": "^8.0.2",
     "craftcms/cms": "^4.0|^5.0"
   },
   "require-dev": {

--- a/src/templates/tags/v3.twig
+++ b/src/templates/tags/v3.twig
@@ -1,11 +1,28 @@
 {{ hiddenInput|raw }}
 <script src="https://www.google.com/recaptcha/api.js?render={{ siteKey }}" {{- scriptAttributes|raw }}></script>
-<script {{- scriptAttributes|raw }}>
-    grecaptcha.ready(function() {
-        grecaptcha.execute("{{ siteKey }}", {
-            action: "{{ action }}"
-        }).then(function(token) {
-            document.getElementById("{{ id }}").value = token;
+{%~ if formId %}
+    <script>
+        grecaptcha.ready(function() {
+            document.getElementById("{{ formId }}").addEventListener("submit", function(event) {
+                event.preventDefault();
+                grecaptcha.execute("{{ siteKey }}", {
+                    action: "{{ action }}"
+                }).then(function(token) {
+                    document.getElementById("{{ id }}").value = token;
+                    document.getElementById("{{ formId }}").submit();
+                });
+            }, false);
+
         });
-    });
-</script>
+    </script>
+{% else %}
+    <script {{- scriptAttributes|raw }}>
+        grecaptcha.ready(function() {
+            grecaptcha.execute("{{ siteKey }}", {
+                action: "{{ action }}"
+            }).then(function(token) {
+                document.getElementById("{{ id }}").value = token;
+            });
+        });
+    </script>
+{% endif ~%}

--- a/src/variables/GoogleRecaptchaVariable.php
+++ b/src/variables/GoogleRecaptchaVariable.php
@@ -64,17 +64,28 @@ class GoogleRecaptchaVariable
 
         $siteKey = App::parseEnv($settings->siteKey);
 
-        $scriptAttributes = isset($options['scriptOptions']) ? Html::renderTagAttributes($options['scriptOptions']) : '';
+        $scriptAttributes = isset($options['scriptOptions']) ? Html::renderTagAttributes(
+            $options['scriptOptions']
+        ) : '';
         ArrayHelper::remove($options, 'scriptOptions');
 
-        if ((int)App::parseEnv($settings->version) === 3) {
+        if ((int) App::parseEnv($settings->version) === 3) {
             $action = $options['action'] ?? $settings->actionName;
             ArrayHelper::remove($options, 'action');
             $formId = $options['formId'] ?? null;
             ArrayHelper::remove($options, 'formId');
             $recaptchaTag = self::_getV3Tag($id, $siteKey, $options, $scriptAttributes, $action, $formId);
         } else {
-            $recaptchaTag = self::_getV2Tag($id, $siteKey, $options, $scriptAttributes, App::parseEnv($settings->size), App::parseEnv($settings->theme), App::parseEnv($settings->badge), $instantRender);
+            $recaptchaTag = self::_getV2Tag(
+                $id,
+                $siteKey,
+                $options,
+                $scriptAttributes,
+                App::parseEnv($settings->size),
+                App::parseEnv($settings->theme),
+                App::parseEnv($settings->badge),
+                $instantRender
+            );
         }
 
         return Template::raw($recaptchaTag);
@@ -94,8 +105,14 @@ class GoogleRecaptchaVariable
      * @throws Exception
      * @throws InvalidConfigException
      */
-    private static function _getV3Tag(string $id, string $siteKey, array $options, string $scriptAttributes, string $action, string $formId = null): string
-    {
+    private static function _getV3Tag(
+        string $id,
+        string $siteKey,
+        array $options,
+        string $scriptAttributes,
+        string $action,
+        string $formId = null,
+    ): string {
         return Craft::$app->getView()->renderTemplate('google-recaptcha/tags/v3', [
             'id' => $id,
             'action' => $action,
@@ -111,18 +128,27 @@ class GoogleRecaptchaVariable
      * @param string $id
      * @param string $siteKey
      * @param array $options
+     * @param string $scriptAttributes
      * @param string $size
      * @param string $theme
      * @param string $badge
      * @param bool $instantRender
      * @return string
-     * @throws \Twig\Error\LoaderError
-     * @throws \Twig\Error\RuntimeError
-     * @throws \Twig\Error\SyntaxError
-     * @throws \yii\base\Exception
+     * @throws Exception
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
      */
-    private static function _getV2Tag(string $id, string $siteKey, array $options, string $scriptAttributes, string $size, string $theme, string $badge, bool $instantRender): string
-    {
+    private static function _getV2Tag(
+        string $id,
+        string $siteKey,
+        array $options,
+        string $scriptAttributes,
+        string $size,
+        string $theme,
+        string $badge,
+        bool $instantRender,
+    ): string {
         return Craft::$app->getView()->renderTemplate('google-recaptcha/tags/v2', [
             'callbackName' => StringHelper::camelCase($id),
             'id' => $id,
@@ -134,5 +160,23 @@ class GoogleRecaptchaVariable
             'badge' => $badge,
             'instantRender' => $instantRender,
         ], View::TEMPLATE_MODE_CP);
+    }
+
+    /**
+     * Return the version setting
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return GoogleRecaptcha::$plugin->getSettings()->version;
+    }
+
+    /**
+     * Return the parsed siteKey setting
+     * @return string
+     */
+    public function getSiteKey(): string
+    {
+        return App::parseEnv(GoogleRecaptcha::$plugin->getSettings()->siteKey);
     }
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -3,8 +3,10 @@
 use craft\test\TestSetup;
 
 ini_set('date.timezone', 'UTC');
+date_default_timezone_set('UTC');
 
 // Use the current installation of Craft
+define('CRAFT_ROOT_PATH', dirname(__DIR__));
 define('CRAFT_TESTS_PATH', __DIR__);
 define('CRAFT_STORAGE_PATH', __DIR__ . '/_craft/storage');
 define('CRAFT_TEMPLATES_PATH', __DIR__ . '/_craft/templates');
@@ -13,9 +15,16 @@ define('CRAFT_MIGRATIONS_PATH', __DIR__ . '/_craft/migrations');
 define('CRAFT_TRANSLATIONS_PATH', __DIR__ . '/_craft/translations');
 define('CRAFT_VENDOR_PATH', dirname(__DIR__) . '/vendor');
 
+// Set some fake env vars for functional tests purpose
+putenv('RECAPTCHA_SITE_KEY=aazertyuiop');
+putenv('RECAPTCHA_SECRET_KEY=aazertyuiop');
+
 $devMode = true;
 
 TestSetup::configureCraft();
 
 // Set the @webroot alias so that the cpresources folder is created in the correct directory
 Craft::setAlias('@webroot', __DIR__ . '/_craft/web');
+
+// Prevent `headers already sent` error
+ob_start();

--- a/tests/_craft/config/db.php
+++ b/tests/_craft/config/db.php
@@ -1,12 +1,17 @@
 <?php
 
+use craft\helpers\App;
+
 return [
-    'password' => getenv('DB_PASSWORD'),
-    'user' => getenv('DB_USER'),
-    'database' => getenv('DB_DATABASE'),
-    'tablePrefix' => getenv('DB_TABLE_PREFIX'),
-    'driver' => getenv('DB_DRIVER'),
-    'port' => getenv('DB_PORT'),
-    'schema' => getenv('DB_SCHEMA'),
-    'server' => getenv('DB_SERVER'),
+    'dsn' => App::env('DB_DSN'),
+    'driver' => App::env('DB_DRIVER'),
+    'server' => App::env('DB_SERVER'),
+    'port' => App::env('DB_PORT'),
+    'database' => App::env('DB_DATABASE'),
+    'user' => App::env('DB_USER'),
+    'password' => App::env('DB_PASSWORD'),
+    'schema' => App::env('DB_SCHEMA'),
+    'tablePrefix' => App::env('DB_TABLE_PREFIX'),
+    'charset' => App::env('DB_CHARSET') ?? 'utf8',
+    'collation' => App::env('DB_COLLATION'),
 ];

--- a/tests/_craft/config/general.php
+++ b/tests/_craft/config/general.php
@@ -1,5 +1,8 @@
 <?php
 
+use craft\helpers\App;
+
 return [
     'devMode' => true,
+    'securityKey' => App::env('SECURITY_KEY'),
 ];

--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -3,7 +3,3 @@ modules:
   enabled:
     - \craft\test\Craft
     - \Helper\Functional
-    - Db:
-        dsn: 'mysql:host=%DB_SERVER%;dbname=%DB_DATABASE%'
-        user: '%DB_USER%'
-        password: '%DB_PASSWORD%'

--- a/tests/functional/CpCest.php
+++ b/tests/functional/CpCest.php
@@ -86,7 +86,7 @@ class CpCest
             ],
         ]);
         $I->seeResponseCodeIs(200);
-        $I->seeCurrentUrlMatches('/admin\/settings$/');
-        $I->seeInDatabase('projectconfig', ['path' => 'plugins.google-recaptcha.settings.version', 'value' => '"3"']);
+        $I->seeCurrentUrlMatches('/' . $this->cpTrigger . '\/settings$/');
+        $I->see('Plugin settings saved.', 'script');
     }
 }

--- a/tests/unit/VariablesTest.php
+++ b/tests/unit/VariablesTest.php
@@ -225,4 +225,20 @@ class VariablesTest extends BaseUnitTest
         $this->assertEquals($matches[8], $matches[12]);
         $this->assertEquals($matches[2], $matches[3]);
     }
+
+    public function testGetVersion(): void
+    {
+        GoogleRecaptcha::$plugin->setSettings([
+            'version' => 3,
+        ]);
+        $this->assertEquals(3, $this->variable->getVersion());
+    }
+
+    public function testGetSiteKey(): void
+    {
+        GoogleRecaptcha::$plugin->setSettings([
+            'siteKey' => 'some-site-key',
+        ]);
+        $this->assertEquals('some-site-key', $this->variable->getSiteKey());
+    }
 }

--- a/tests/unit/VariablesTest.php
+++ b/tests/unit/VariablesTest.php
@@ -22,7 +22,8 @@ use UnitTester;
 class VariablesTest extends BaseUnitTest
 {
     public const V2_OUTPUT_PATTERN = '/<div id="([\w-]+?)"><\/div>\s+<script type="text\/javascript"((\s+\w+?(=".+?")?)*)?>\s+var (\w+?) = function\(\) {\s+var widgetId = grecaptcha.render\("([\w-]+?)", {\s+(.*?)\s+}\);\s+(.*?)?};\s+(.*?\s+)?<\/script>\s+<script src="https:\/\/www.google.com\/recaptcha\/api\.js\?onload=(\w+?)&render=explicit&hl=([\w-]+?)" async defer((\s+\w+?(=".+?")?)*)?><\/script>/s';
-    public const V3_OUTPUT_PATTERN = '/<script src="https:\/\/www.google.com\/recaptcha\/api\.js\?render=([\w-]+?)"((\s+\w+?(=".+?")?)*)?><\/script>\s+<script((\s+\w+?(=".+?")?)*)?>\s+grecaptcha.ready\(function\(\) {\s+grecaptcha\.execute\("([\w-]+?)", {\s+action\: "(\w+?)"\s+}\)\.then\(function\(token\) {\s+document\.getElementById\("([\w-]+?)"\)\.value = token;\s+}\);\s+}\);\s+<\/script>/s';
+    public const V3_OUTPUT_PATTERN_SIMPLE = '/<script src="https:\/\/www.google.com\/recaptcha\/api\.js\?render=([\w-]+?)"((\s+\w+?(=".+?")?)*)?><\/script>\s+<script((\s+\w+?(=".+?")?)*)?>\s+grecaptcha.ready\(function\(\) {\s+grecaptcha\.execute\("([\w-]+?)", {\s+action\: "(\w+?)"\s+}\)\.then\(function\(token\) {\s+document\.getElementById\("([\w-]+?)"\)\.value = token;\s+}\);\s+}\);\s+<\/script>/s';
+    public const V3_OUTPUT_PATTERN_WITH_FORMID = '/<script src="https:\/\/www.google.com\/recaptcha\/api\.js\?render=([\w-]+?)"((\s+\w+?(=".+?")?)*)?><\/script>\s+<script((\s+\w+?(=".+?")?)*)?>\s+grecaptcha.ready\(function\(\) {\s+document\.getElementById\("(.*?)\"\)\.addEventListener\("submit\"\,\s+function\(event\)\s+{\s+event\.preventDefault\(\);\s+grecaptcha\.execute\(\"(.*?)\",\s+{\s+action:\s+"(.*?)\"\s+}\)\.then\(function\(token\)\s+{\s+document\.getElementById\(\"(.*?)\"\)\.value\s+=\s+token;\s+document\.getElementById\(\"(.*?)\"\)\.submit\(\);\s+}\);\s+},\s+false\);\s+}\);\s+<\/script>/s';
     /**
      * @var UnitTester
      */
@@ -163,7 +164,7 @@ class VariablesTest extends BaseUnitTest
             'secretKey' => 'some-secret-key',
         ]);
         $output = $this->variable->render();
-        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN, $output, $matches);
+        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN_SIMPLE, $output, $matches);
         $this->assertTrue($isValid);
         $this->assertEquals($matches[1], $matches[8]);
         $this->assertStringContainsString('some-site-key', $matches[1]);
@@ -183,7 +184,7 @@ class VariablesTest extends BaseUnitTest
             'secretKey' => 'some-secret-key',
         ]);
         $output = $this->variable->render(['id' => 'my-recaptcha']);
-        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN, $output, $matches);
+        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN_SIMPLE, $output, $matches);
         $this->assertTrue($isValid);
         $this->assertStringContainsString('homepage', $matches[9]);
         $this->assertStringContainsString('my-recaptcha', $matches[10]);
@@ -197,7 +198,7 @@ class VariablesTest extends BaseUnitTest
             'secretKey' => 'some-secret-key',
         ]);
         $output = $this->variable->render(['scriptOptions' => ['nonce' => '123456Z']]);
-        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN, $output, $matches);
+        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN_SIMPLE, $output, $matches);
         $this->assertTrue($isValid);
         $this->assertEquals($matches[1], $matches[8]);
         $this->assertStringContainsString('some-site-key', $matches[1]);
@@ -207,5 +208,21 @@ class VariablesTest extends BaseUnitTest
         $this->assertStringContainsString('nonce="123456Z"', $matches[6]);
         $this->assertStringContainsString('some-site-key', $matches[8]);
         $this->assertStringContainsString('homepage', $matches[9]);
+    }
+
+    public function testRenderV3WithFormIdOptions(): void
+    {
+        GoogleRecaptcha::$plugin->setSettings([
+            'version' => 3,
+            'siteKey' => 'some-site-key',
+            'secretKey' => 'some-secret-key',
+        ]);
+        $output = $this->variable->render(['formId' => 'some-form-id', 'scriptOptions' => ['nonce' => '123456Z']]);
+        $isValid = (bool)preg_match(self::V3_OUTPUT_PATTERN_WITH_FORMID, $output, $matches);
+        $this->assertTrue($isValid);
+        $this->assertStringContainsString('some-form-id', $matches[8]);
+        $this->assertStringContainsString('nonce="123456Z"', $matches[2]);
+        $this->assertEquals($matches[8], $matches[12]);
+        $this->assertEquals($matches[2], $matches[3]);
     }
 }


### PR DESCRIPTION
## Why

5aday was losing resource orders to "Please, prove you're not a robot." Production logs showed every rejection of that form was `timeout-or-duplicate`, on real browsers with a full-length token:

| Attempt | Browser | Load → submit | Result |
|---|---|---|---|
| 1 | Safari 26.5 / macOS | 3 min 18 s | ❌ `timeout-or-duplicate` |
| 2 | Safari 26.5 | same second | ✅ success |
| 3 | Safari 26.5 | 2 min 27 s | ❌ `timeout-or-duplicate` |
| 4 | Chrome | same second | ✅ success |

A v3 token expires two minutes after it is minted. This plugin minted it on page load, so any form slower than that to fill in was rejected. Browser was irrelevant — a Chrome-on-Android submission failed the same way, and Safari succeeded whenever it submitted promptly.

## What

Merges upstream `juban/craft-google-recaptcha` through 97e3fc3, which already solved this with a `formId` option that defers `grecaptcha.execute()` to the form's `submit` event — our fork had diverged at `f95728a` and never picked it up. Also brings in the `getVersion`/`getSiteKey` Twig variables.

Conflicts resolved keeping our side: PHP `^8.2` and Craft `^5` only, CI on 8.2. README taken from upstream (the conflict was pure reflow).

### Hardening over upstream

- **The submit listener is delegated from the `document`**, and the form and field are looked up when needed rather than held onto. Bound directly to the form node it is silently lost on any page that re-renders after parse — verified on 5aday, where a Vue app mounts on the page wrapper with the runtime-compiler build and replaces every node, so the captured form was detached before the user clicked Send and the token field posted empty. Applies equally to htmx and Turbo.
- **`scriptOptions` now reach the script tag**, so a CSP `nonce` is applied. Upstream omitted them, which meant the script was blocked under a strict CSP.
- **The form submits even if `execute()` rejects or hangs** (10s cap). Upstream left the promise unhandled, so a failed or slow reCAPTCHA call left the submit button permanently dead — worse than the bug being fixed. Verification stays server-side, so this weakens nothing.
- **Submits made before the API initialises** wait for a token instead of posting an empty field.
- **Repeated clicks** while a token is in flight no longer fire several `execute()` calls.
- Interpolated values are JSON-encoded rather than pasted into bare JS string literals, and `$formId` is explicitly nullable (PHP 8.4 deprecation).

## Testing

Verified end to end against a real Craft 5 install: form loaded, filled, left idle **4 minutes**, then submitted — order saved, no reCAPTCHA rejection logged. The same test before the delegation fix failed with `invalid-input-response` and a zero-length token, which is how the re-render problem was found.

Upstream's unit test matched the whole script body with one exact-shape regex, so any reformatting broke it. Replaced with assertions on behaviour: the token is minted inside the submit listener, the form still submits when reCAPTCHA fails, the listener is delegated rather than bound to the form, and the nonce reaches both script tags. That last assertion was already in upstream's test but could never have passed, since its template omitted `scriptOptions`.

## Note

This fork's `3.0.0`–`3.0.6` tags are unrelated to upstream's `3.0.0`, hence `3.1.0` rather than reusing a number. `3.1.0` is tagged at the tip of this branch — if review changes anything, the tag needs re-cutting.